### PR TITLE
Also use Escape key to focus on input search box, and select all text in input search box

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Store](https://chrome.google.com/webstore/detail/enhanced-keyboard-navigat/coham
 
 *   `↓`/`j`: Select next search result
 *   `↑`/`k`: Select previous previous result
-*   `/`: Focus on input search box
+*   `/`/`Escape`: Focus on input search box
 *   `Enter`/`Space`: Navigate to selected result
 *   `Ctrl+Enter`/`⌘+Enter`/`Ctrl+Space`: Open selected result in new tab/window
 

--- a/google_keyboard_shortcuts.js
+++ b/google_keyboard_shortcuts.js
@@ -95,8 +95,9 @@ const initPage = () => {
     event.preventDefault();
   });
   let searchInput = document.getElementById('lst-ib');
-  key('/', (event) => {
+  key('/, escape', (event) => {
     searchInput.focus();
+    searchInput.select();
     event.stopPropagation();
     event.preventDefault();
   });

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Google Search Navigator",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "description": "Adds keyboard shortcuts to Google Search (google.com).",
     "content_scripts": [{
         "matches": [


### PR DESCRIPTION
Before Google removed keyboards shortcuts from Google Search, you could return focus to the input search box by pressing the Escape key. This also caused all current text in the input search box to be selected. This pull request contains these additions.