### PR TITLE
Add keyboard navigation to different tabs (like Images, Videos, etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Store](https://chrome.google.com/webstore/detail/enhanced-keyboard-navigat/coham
 *   `/`/`Escape`: Focus on input search box
 *   `Enter`/`Space`: Navigate to selected result
 *   `Ctrl+Enter`/`⌘+Enter`/`Ctrl+Space`: Open selected result in new tab/window
+*   `a`/`s`: Navigate to All tab (= default search tab)
+*   `i`: Navigate to Images tab
+*   `v`: Navigate to Videos tab
+*   `m`: Navigate to Maps tab
+*   `n`: Navigate to News tab
 
 ## TODO
 

--- a/options.html
+++ b/options.html
@@ -55,6 +55,36 @@
             </div>
             <input id="navigate-new-tab-key" class="input-keybinding" type="text" value="ctrl+return, command+return, ctrl+space">
         </div>
+        <div class="option">
+            <div class="option-desc">
+                Navigate to All tab (= default search tab)
+            </div>
+            <input id="navigate-search-tab" class="input-keybinding" type="text" value="a, s">
+        </div>
+        <div class="option">
+            <div class="option-desc">
+                Navigate to Images tab
+            </div>
+            <input id="navigate-images-tab" class="input-keybinding" type="text" value="i">
+        </div>
+        <div class="option">
+            <div class="option-desc">
+                Navigate to Videos tab
+            </div>
+            <input id="navigate-videos-tab" class="input-keybinding" type="text" value="v">
+        </div>
+        <div class="option">
+            <div class="option-desc">
+                Navigate to Maps tab
+            </div>
+            <input id="navigate-maps-tab" class="input-keybinding" type="text" value="m">
+        </div>
+        <div class="option">
+            <div class="option-desc">
+                Navigate to News tab
+            </div>
+            <input id="navigate-news-tab" class="input-keybinding" type="text" value="n">
+        </div>
     </div>
 
     <div id="status"></div>

--- a/options.js
+++ b/options.js
@@ -11,6 +11,16 @@ const saveOptions = () => {
         navigateKey: document.getElementById('navigate-key').value,
         navigateNewTabKey:
             document.getElementById('navigate-new-tab-key').value,
+        navigateSearchTab: 
+            document.getElementById('navigate-search-tab').value,
+        navigateImagesTab: 
+            document.getElementById('navigate-images-tab').value,
+        navigateVideosTab: 
+            document.getElementById('navigate-videos-tab').value,
+        navigateMapsTab: 
+            document.getElementById('navigate-maps-tab').value,
+        navigateNewsTab: 
+            document.getElementById('navigate-news-tab').value,
       },
       () => {
         // Update status to let user know options were saved.
@@ -33,6 +43,11 @@ const restoreOptions = () => {
         previousKey: 'up, k',
         navigateKey: 'return, space',
         navigateNewTabKey: 'ctrl+return, command+return, ctrl+space',
+        navigateSearchTab: 'a, s',
+        navigateImagesTab: 'i',
+        navigateVideosTab: 'v',
+        navigateMapsTab: 'm',
+        navigateNewsTab: 'n'
       },
       (items) => {
         document.getElementById('wrap-navigation').checked =
@@ -44,6 +59,16 @@ const restoreOptions = () => {
         document.getElementById('navigate-key').value = items.navigateKey;
         document.getElementById('navigate-new-tab-key').value =
             items.navigateNewTabKey;
+        document.getElementById('navigate-search-tab').value =
+            items.navigateSearchTab;
+        document.getElementById('navigate-images-tab').value =
+            items.navigateImagesTab;
+        document.getElementById('navigate-videos-tab').value =
+            items.navigateVideosTab;
+        document.getElementById('navigate-maps-tab').value =
+            items.navigateMapsTab;
+        document.getElementById('navigate-news-tab').value =
+            items.navigateNewsTab;
       });
 };
 


### PR DESCRIPTION
These changes make it possible to navigate to the different tabs in Google, like Images, Videos etc.
The default keybindings can be reassigned in the settings.

The chosen solution is slightly different than proposed in #7, but this might resolve it anyway.