### PR TITLE
fix loading option values into form

### DIFF
--- a/options.js
+++ b/options.js
@@ -63,9 +63,9 @@ const restoreOptions = () => {
         document.getElementById('next-key').value = items.nextKey;
         document.getElementById('previous-key').value = items.previousKey;
         document.getElementById('navigate-previous-result-page').value =
-            items.navigateNewsTab;
+            items.navigatePreviousResultPage;
         document.getElementById('navigate-next-result-page').value =
-            items.navigateNewsTab;
+            items.navigateNextResultPage;
         document.getElementById('navigate-key').value = items.navigateKey;
         document.getElementById('navigate-new-tab-key').value =
             items.navigateNewTabKey;


### PR DESCRIPTION
The form's option values for previous/next result page shortcut wasn't loading properly. This fixes the issue.