### PR TITLE
Firefox publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@ have been [removed as of
 In addition, I wanted to add new keyboard shortcuts and the existing ones to be
 more vim like (j/k for navigation).
 
-Install from the [Chrome Web
-Store](https://chrome.google.com/webstore/detail/enhanced-keyboard-navigat/cohamjploocgoejdfanacfgkhjkhdkek)
+## Installation
+
+* for Chrome: Install from the [Chrome Web
+Store](https://chrome.google.com/webstore/detail/enhanced-keyboard-navigat/cohamjploocgoejdfanacfgkhjkhdkek).
+* for Firefox: Install from the [Add-ons for Firefox](https://addons.mozilla.org/cs/firefox/addon/the-google-search-navigator/).
 
 ## Keybindings
 

--- a/docs/publish-instructions.md
+++ b/docs/publish-instructions.md
@@ -2,12 +2,14 @@
 
 Guides how to publish the new versions of the extension.
 
-Please, do not release builds of versions for which are not committed.
+Please, do not release builds of versions for which are not committed. Meaning you should not release a version X when there is no matching commit, where X is denoted in the `manifest.json`. 
 
 # Pre-build
 
 * Just update version number in the `src/manifest.json`. There is no `version` field in the `package.json` so you don't need to worry about it.
 * Commit with the message "v1.2.3" with the actual version in it. 
+
+Do this only once for all builds (Chrome, Firefox,...).
  
 # Firefox
 

--- a/docs/publish-instructions.md
+++ b/docs/publish-instructions.md
@@ -1,0 +1,18 @@
+# Publish instructions
+
+Guides how to publish the new versions of the extension.
+
+Please, do not release builds of versions for which are not committed.
+
+# Pre-build
+
+* Just update version number in the `src/manifest.json`. There is no `version` field in the `package.json` so you don't need to worry about it.
+* Commit with the message "v1.2.3" with the actual version in it. 
+ 
+# Firefox
+
+* After completing pre-build instructions run `./tools/make-firefox.sh`.
+* The add-on archive will be placed under `./build/firefox/goole_search_navigator-<version>.zip`.
+* Open the [upload new version]((https://addons.mozilla.org/cs/developers/addon/the-google-search-navigator/versions/submit/)) page.
+* Only upload the produced archive and click "Continue".
+* Provide the version notes and you are done!   

--- a/package.json
+++ b/package.json
@@ -3,6 +3,15 @@
   "description": "Adds keyboard shortcuts to Google Search (google.com).",
   "repository": "https://github.com/infokiller/google-search-navigator",
   "author": "https://github.com/infokiller",
+  "contributors": [
+    {
+      "name": "infokiller"
+    },
+    {
+      "name": "Michal Novák",
+      "url": "https://www.weborama.cz/"
+    }
+  ],
   "license": "MIT",
   "scripts": {
     "build": "gulp"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,6 @@
 {
   "name": "google-search-navigator",
-  "version": "0.2.5",
   "description": "Adds keyboard shortcuts to Google Search (google.com).",
-  "main": "google_keyboard_shortcuts.js",
   "repository": "https://github.com/infokiller/google-search-navigator",
   "author": "https://github.com/infokiller",
   "license": "MIT",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,6 +3,12 @@
     "name": "Google Search Navigator",
     "version": "0.2.7",
     "description": "Adds keyboard shortcuts to Google Search (google.com).",
+    "applications": {
+        "gecko": {
+            "id": "{ffadac89-63bb-4b04-be90-8cb2aa323171}",
+            "strict_min_version": "48.0"
+        }
+    },
     "content_scripts": [{
         "matches": [
             "*://www.google.com/search*",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Google Search Navigator",
-    "version": "0.2.5",
+    "version": "0.2.7",
     "description": "Adds keyboard shortcuts to Google Search (google.com).",
     "content_scripts": [{
         "matches": [

--- a/tools/make-firefox.sh
+++ b/tools/make-firefox.sh
@@ -28,8 +28,9 @@ mkdir -p "$OBJ"
 cp src/* "$OBJ"
 cp .web-extension-id "$OBJ"
 
-# pack and sign the package
+# build and pack the package
+# do not sign as it would result in signed add-on intended for self-distribution
 echo "Creating package..."
-web-ext sign --source-dir "$OBJ" --artifacts-dir "$BIN" "$@"
+web-ext build --source-dir "$OBJ" --artifacts-dir "$BIN" "$@"
 
 echo "Build complete"

--- a/tools/make-firefox.sh
+++ b/tools/make-firefox.sh
@@ -26,7 +26,6 @@ rm -rf "$OBJ"
 mkdir -p "$OBJ"
 
 cp src/* "$OBJ"
-cp .web-extension-id "$OBJ"
 
 # build and pack the package
 # do not sign as it would result in signed add-on intended for self-distribution


### PR DESCRIPTION
Fixes #13.

The main struggle I had was with the extension id needed in the `manifest.json` file. I have already elaborated on this and commented previously. It turns out it is much better to have extension id in the manifest file and not in the `.web-extension-id`. At least from the point of publishing for AMO portal. It should make no harm for Chrome aside that when loading unpacked from directory, warning is displayed (yet extension works).

If it would be any trouble in the future then manipulating `manifest.json` in the build script for Chrome would be way to go I think.

In addition of other miscellaneous fixes I gave myself a little credit in the list of contributors in `package.json` :). I hope its fine.

