### PR TITLE
fix Firefox opening link twice when using open in a new tab shortcut

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -92,7 +92,9 @@ const extension = {
     });
     this.register(options.navigateNewTabKey, () => {
       const link = results.items[results.focusedIndex];
-      window.open(link.href);
+      // NOTE: Firefox (tested in 58) somehow from single window.open() opened
+      // a link twice. Using timeout solves the issue.
+      window.setTimeout(() => window.open(link.href));
     });
     this.register(options.navigateNewTabBackgroundKey, () => {
       const link = results.items[results.focusedIndex];


### PR DESCRIPTION
For me the Firefox was opening a link twice when using "open in a new tab" shortcut. I wasn't able to find out why it does so. However I have found out a simple workaround implemented in this PR.