### PR TITLE
Ensure whole search result container is scrolled into view on focus

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -180,18 +180,18 @@ function OptionSection(storage, defaultValues) {
 }
 
 /**
- * @param {...[Element[], function|null]} var_args The array of tuples.
+ * @param {...[Element[], function|null]} results The array of tuples.
  * Each tuple contains collection of the search results optionally accompanied
  * with their container selector.
  * @constructor
  */
-function SearchResultCollection(var_args) {
+function SearchResultCollection(...results) {
   /**
    * @type {SearchResult[]}
    */
   this.items = [];
-  for (let i = 0; i < arguments.length; i++) {
-    const params = arguments[i];
+  for (let i = 0; i < results.length; i++) {
+    const params = results[i];
     const nodes = params[0];
     const containerSelector = params[1];
     for (let j = 0; j < nodes.length; j++) {

--- a/src/extension.js
+++ b/src/extension.js
@@ -218,12 +218,17 @@ function SearchResultCollection(...results) {
     const newItem = this.items[index];
     newItem.anchor.classList.add('highlighted-search-result');
     newItem.anchor.focus();
+    // ensure whole search result container is visible in the viewport, not only
+    // the search result link
     const container = newItem.getContainer() || newItem.anchor;
     const containerBounds = container.getBoundingClientRect();
-    // firefox displays tooltip at the bottom which obstructs the view;
-    // bottomDelta is a workaround to it
+    // firefox displays tooltip at the bottom which obstructs the view
+    // as a workaround ensure extra space from the bottom in the viewport
+    // firefox detection (https://stackoverflow.com/a/7000222/2870889)
     const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
-    const bottomDelta = (isFirefox ? 26 : 0);
+    // hardcoded height of the tooltip plus some margin
+    const firefoxBottomDelta = 26;
+    const bottomDelta = (isFirefox ? firefoxBottomDelta: 0);
     if (containerBounds.top < 0) {
       // scroll container to top
       container.scrollIntoView(true);


### PR DESCRIPTION
Fixes #42.

The extension will now scroll the whole search result container into view when it is not fully visible after search result anchor is focused.

This mainly affects Firefox as the Chrome handles the scrolling on focus change in a better way and no scroll adjustment is needed in its case.