### PR TITLE
Fix always linking to Czech Firefox Add-ons in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ more vim like (j/k for navigation).
 
 * for Chrome: Install from the [Chrome Web
 Store](https://chrome.google.com/webstore/detail/enhanced-keyboard-navigat/cohamjploocgoejdfanacfgkhjkhdkek).
-* for Firefox: Install from the [Add-ons for Firefox](https://addons.mozilla.org/cs/firefox/addon/the-google-search-navigator/).
+* for Firefox: Install from the [Add-ons for Firefox](https://addons.mozilla.org/firefox/addon/the-google-search-navigator/).
 
 ## Keybindings
 


### PR DESCRIPTION
The README file currently has a link to the Czech Firefox Add-ons website. This pull request removes the language from the link, so the user's language preference is respected.