### PR TITLE
Remove Tabs Permission

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -408,8 +408,7 @@
         "*://www.google.co.zw/search*",
         "*://www.google.cat/search*",
         "*://encrypted.google.com/*",
-        "storage",
-        "tabs"
+        "storage"
     ],
     "options_ui": {
         "page": "options.html",


### PR DESCRIPTION
removed unnecessary tabs permission to so that chrome does not give warning about reading browsing history mentioned in #53 