### PR TITLE
shortcuts for search tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 build/
 node_modules/
 src/keymaster.js
+yarn-error.log
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ _Note: All shortcuts can be customized to your liking via options._
 *   `b`: Navigate to books tab
 *   `alt+l`: Navigate to flights tab
 *   `f`: Navigate to financial tab
+*	`Ctrl+Shift+h`: Filter results by past hour
+*	`Ctrl+Shift+d`: Filter results by past 24 hours (day)
+*	`Ctrl+Shift+w`: Filter results by past week
+*	`Ctrl+Shift+m`: Filter results by past month
+*	`Ctrl+Shift+y`: Filter results by past year
+*	`Ctrl+Shift+a`: Turn off filter (show all results)
+*	`Ctrl+Shift+s`: Toggle sort by date/relevance (only when filtering)
 
 ## Development
 

--- a/assets/chrome_webstore_description.txt
+++ b/assets/chrome_webstore_description.txt
@@ -41,3 +41,10 @@ more vim like (j/k for navigation).
 *   `b`: Navigate to books tab
 *   `alt+l`: Navigate to flights tab
 *   `f`: Navigate to financial tab
+*	`Ctrl+Shift+h`: Filter results by past hour
+*	`Ctrl+Shift+d`: Filter results by past 24 hours (day)
+*	`Ctrl+Shift+w`: Filter results by past week
+*	`Ctrl+Shift+m`: Filter results by past month
+*	`Ctrl+Shift+y`: Filter results by past year
+*	`Ctrl+Shift+a`: Turn off filter (show all results)
+*	`Ctrl+Shift+s`: Toggle sort by date/relevance (only when filtering)

--- a/src/extension.js
+++ b/src/extension.js
@@ -62,7 +62,7 @@ const extension = {
     loadOptions.then(() => this.initCommonGoogleSearchNavigation());
   },
 
-  changeTools(period, sort) {
+  changeTools(period) {
     // Save current period and sort.
     const res = /&(tbs=qdr:.)(,sbd:.)?/.exec(location.href)
     const currPeriod = (res && res[1]) || ''
@@ -72,9 +72,8 @@ const extension = {
     if (period) {
       location.href = strippedHref + (period === 'a' ? '' : '&tbs=qdr:' + period + currSort)
     }
-    else if (sort) {
+    else if (currPeriod) {
       // Can't apply sort when not using period.
-      if (!currPeriod) { return; }
       location.href = strippedHref + '&' + currPeriod + (currSort ? '' : ',sbd:1')
     }
   },
@@ -134,7 +133,7 @@ const extension = {
     this.register(options.navigateShowWeek, () => this.changeTools('w'));
     this.register(options.navigateShowMonth, () => this.changeTools('m'));
     this.register(options.navigateShowYear, () => this.changeTools('y'));
-    this.register(options.toggleSort, () => this.changeTools(null, 1));
+    this.register(options.toggleSort, () => this.changeTools(null));
   },
 
   initCommonGoogleSearchNavigation() {

--- a/src/extension.js
+++ b/src/extension.js
@@ -63,20 +63,18 @@ const extension = {
   },
 
   changeTools(period, sort) {
-    // save current period, sort
+    // Save current period and sort.
     const res = /&(tbs=qdr:.)(,sbd:.)?/.exec(location.href)
     const currPeriod = (res && res[1]) || ''
     const currSort = (res && res[2]) || ''
-    // remove old period, sort
+    // Remove old period and sort.
     const strippedHref = location.href.replace(/&tbs=qdr:.(,sbd:.)?/, '')
-    // changing period
-    if(period) {
+    if (period) {
       location.href = strippedHref + (period === 'a' ? '' : '&tbs=qdr:' + period + currSort)
     }
-    // changing sort
-    else if(sort) {
-      // can't apply sort when not using period
-      if(!currPeriod) { return }
+    else if (sort) {
+      // Can't apply sort when not using period.
+      if (!currPeriod) { return; }
       location.href = strippedHref + '&' + currPeriod + (currSort ? '' : ',sbd:1')
     }
   },

--- a/src/extension.js
+++ b/src/extension.js
@@ -22,7 +22,14 @@ const extension = {
         navigateBooksTab: 'b',
         navigateFlightsTab: 'alt+l',
         navigateFinancialTab: 'f',
-        focusSearchInput: '/, escape'
+        focusSearchInput: '/, escape',
+        navigateShowAll: 'ctrl+shift+a',
+        navigateShowHour: 'ctrl+shift+h',
+        navigateShowDay: 'ctrl+shift+d',
+        navigateShowWeek: 'ctrl+shift+w',
+        navigateShowMonth: 'ctrl+shift+m',
+        navigateShowYear: 'ctrl+shift+y',
+        toggleSort: 'ctrl+shift+s'
       }
     ),
 
@@ -53,6 +60,25 @@ const extension = {
       loadOptions.then(() => this.initResultsNavigation());
     }
     loadOptions.then(() => this.initCommonGoogleSearchNavigation());
+  },
+
+  changeTools(period, sort) {
+    // save current period, sort
+    const res = /&(tbs=qdr:.)(,sbd:.)?/.exec(location.href)
+    const currPeriod = (res && res[1]) || ''
+    const currSort = (res && res[2]) || ''
+    // remove old period, sort
+    const strippedHref = location.href.replace(/&tbs=qdr:.(,sbd:.)?/, '')
+    // changing period
+    if(period) {
+      location.href = strippedHref + (period === 'a' ? '' : '&tbs=qdr:' + period + currSort)
+    }
+    // changing sort
+    else if(sort) {
+      // can't apply sort when not using period
+      if(!currPeriod) { return }
+      location.href = strippedHref + '&' + currPeriod + (currSort ? '' : ',sbd:1')
+    }
   },
 
   initResultsNavigation() {
@@ -104,6 +130,13 @@ const extension = {
       const link = results.items[results.focusedIndex];
       chrome.runtime.sendMessage({type: 'tabsCreate', options: {url: link.anchor.href, active: false}});
     });
+    this.register(options.navigateShowAll, () => this.changeTools('a'));
+    this.register(options.navigateShowHour, () => this.changeTools('h'));
+    this.register(options.navigateShowDay, () => this.changeTools('d'));
+    this.register(options.navigateShowWeek, () => this.changeTools('w'));
+    this.register(options.navigateShowMonth, () => this.changeTools('m'));
+    this.register(options.navigateShowYear, () => this.changeTools('y'));
+    this.register(options.toggleSort, () => this.changeTools(null, 1));
   },
 
   initCommonGoogleSearchNavigation() {


### PR DESCRIPTION
Search Tools support

Filter results by past hour: ctrl+shift+h
Filter results by past 24hrs: ctrl+shift+d
Filter results by past week: ctrl+shift+w
Filter results by past month: ctrl+shift+m
Filter results by past year: ctrl+shift+y
Turn off filter: ctrl+shift+a
Toggle sort by date/relevance: ctrl+shift+s (only if filtering)