### PR TITLE
Fix options for Firefox

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -420,6 +420,10 @@
         "storage"
     ],
     "options_page": "options.html",
+    "options_ui": {
+        "page": "options.html",
+        "chrome_style": true
+    },
     "icons": {
         "16": "icon16.png",
         "48": "icon48.png",


### PR DESCRIPTION
The PR #51 caused options to stop working in Firefox browser. The extension appeared to have no options (the options button disappeared). This is because manifest key `options_ui` was replaced with `options_page` by the PR. The latter key is not supported by the Firefox.

I have restored the `options_ui` key so that it now coexists with `options_page`. And it works. Firefox knows only `options_ui`, so it skips `options_page`. Vice-versa for Edge. Only Chrome recognizes both keys - yet it somehow handles it and options work there. So I think this is the simplest solution.

(At first I thought about having sources patched during the build process for the needs of specific browser but it would be much more complicated and troubling for debugging purposes /running unpacked directly from `src`/.)