### PR TITLE
Update search form input box selector

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -139,7 +139,7 @@ const extension = {
   initCommonGoogleSearchNavigation() {
     const options = this.options.sync.values;
     this.register(options.focusSearchInput, () => {
-      const searchInput = document.getElementById('lst-ib');
+      const searchInput = getElementByXpath("//*[@id='searchform']//input[@name='q']");
       searchInput.focus();
       searchInput.select();
     });


### PR DESCRIPTION
The new XPath should match the input even when id attribute is misssing which is the case of #71.