### PR TITLE
Support for new search result structure

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -342,7 +342,7 @@ function getQueryStringParams() {
 function getGoogleSearchLinks() {
   // the nodes are returned in the document order which is what we want
   return new SearchResultCollection(
-    [document.querySelectorAll('h3.r a'), (n) => n.parentElement.parentElement],
+    [document.querySelectorAll('#search .r > a'), (n) => n.parentElement.parentElement],
     [document.querySelectorAll('div.zjbNbe > a'), null],
     [document.querySelectorAll('div.eIuuYe a'), null], // shopping results
     [document.querySelectorAll('#pnprev, #pnnext'), null]


### PR DESCRIPTION
`#search .r a` as a selector does not work as `.r` elements do contain multiple links in the new structure.

I've done testing with `#search .r > a` instead and this seems to work well. With it I'm able to use keyboard navigation on all tabs _except_ images and finance (which I think is expected). However there are some minor differences:

**Before**
![image](https://user-images.githubusercontent.com/114549/45585872-3b323300-b8e4-11e8-8080-ed46cfe0552c.png)

**After**
![image](https://user-images.githubusercontent.com/114549/45585874-45543180-b8e4-11e8-869d-d34750b18e73.png)

* To precisely match appearance, either `.highlighted-search-result` should be added to the `h3` _inside_ the link instead of to the link itself, or the CSS needs to change. The new `a` tag encompasses both the h3 and the text URL displayed below.
* The new styling does not have a focus rectangle around links. Not a problem for most items, but you can no longer tell which of prev/next is focused when both are present.