### PR TITLE
Ignore Google Translate links next to results

### DIFF
--- a/assets/chrome_webstore_description.txt
+++ b/assets/chrome_webstore_description.txt
@@ -1,3 +1,6 @@
+New in 0.2.15
+* Fixed "translate this site"-links being indexed as search results.
+
 New in 0.2.14:
 * Fixed search results matching in a new (or alternate?) Google Search version.
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -342,7 +342,7 @@ function getQueryStringParams() {
 function getGoogleSearchLinks() {
   // the nodes are returned in the document order which is what we want
   return new SearchResultCollection(
-    [document.querySelectorAll('#search .r > a:first-child'), (n) => n.parentElement.parentElement],
+    [document.querySelectorAll('#search .r > a:first-of-type'), (n) => n.parentElement.parentElement],
     [document.querySelectorAll('div.zjbNbe > a'), null],
     [document.querySelectorAll('div.eIuuYe a'), null], // shopping results
     [document.querySelectorAll('#pnprev, #pnnext'), null]

--- a/src/extension.js
+++ b/src/extension.js
@@ -342,7 +342,7 @@ function getQueryStringParams() {
 function getGoogleSearchLinks() {
   // the nodes are returned in the document order which is what we want
   return new SearchResultCollection(
-    [document.querySelectorAll('#search .r > a'), (n) => n.parentElement.parentElement],
+    [document.querySelectorAll('#search .r > a:first-child'), (n) => n.parentElement.parentElement],
     [document.querySelectorAll('div.zjbNbe > a'), null],
     [document.querySelectorAll('div.eIuuYe a'), null], // shopping results
     [document.querySelectorAll('#pnprev, #pnnext'), null]

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Google Search Navigator",
-    "version": "0.2.14",
+    "version": "0.2.15",
     "description": "Adds keyboard shortcuts to Google Search (google.com).",
     "applications": {
         "gecko": {


### PR DESCRIPTION
Skips selection of "translate site" for links in another language than your geographical region.

![sep-20-2018 18-06-49](https://user-images.githubusercontent.com/13849353/45831651-3b756880-bd00-11e8-97bd-6dd734b3731e.gif)
